### PR TITLE
Install windows and android apps

### DIFF
--- a/intimacy-ai/platform/windows/WpfApp/MainWindow.xaml
+++ b/intimacy-ai/platform/windows/WpfApp/MainWindow.xaml
@@ -1,27 +1,7 @@
 <Window x:Class="WpfApp.MainWindow"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-        Title="Intimacy AI" Height="240" Width="420">
-  <Grid Margin="12">
-    <Grid.RowDefinitions>
-      <RowDefinition Height="Auto"/>
-      <RowDefinition Height="*"/>
-      <RowDefinition Height="Auto"/>
-    </Grid.RowDefinitions>
-    <StackPanel Orientation="Horizontal" Margin="0,0,0,8">
-      <Button Width="120" Margin="0,0,8,0" Content="Connect" Click="OnConnect"/>
-      <Button Width="120" Margin="0,0,8,0" Content="Windows Hello" Click="OnHello"/>
-      <Button Width="120" Margin="0,0,8,0" Content="Tray" Click="OnTray"/>
-      <Button Width="120" Content="Notify" Click="OnNotify"/>
-    </StackPanel>
-    <Border Grid.Row="1" BorderBrush="#DDD" BorderThickness="1" Padding="8">
-      <TextBlock Name="StatusText" Text="Status: idle"/>
-    </Border>
-    <TextBlock Grid.Row="2" Margin="0,8,0,0" Text="Demo UI for platform integration"/>
-  </Grid>
-</Window>
-
-<Window x:Class="WpfApp.MainWindow" xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" Title="IntimacyAI" Height="350" Width="525">
+        Title="IntimacyAI" Height="350" Width="525">
   <Grid>
     <StackPanel Margin="20">
       <TextBlock Text="Windows Demo" FontSize="22"/>

--- a/intimacy-ai/platform/windows/install-windows.ps1
+++ b/intimacy-ai/platform/windows/install-windows.ps1
@@ -6,7 +6,7 @@ Write-Host "[IntimacyAI] Windows install starting..." -ForegroundColor Cyan
 
 # Ensure we run from repo root regardless of invocation path
 $ScriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
-$RepoRoot  = Resolve-Path (Join-Path $ScriptDir '..' '..' '..')
+$RepoRoot  = Resolve-Path (Join-Path $ScriptDir '..\..\..')
 Set-Location $RepoRoot
 
 # Prefer local .NET if present (matches README conventions)

--- a/intimacy-ai/src/Server/Program.cs
+++ b/intimacy-ai/src/Server/Program.cs
@@ -1,7 +1,6 @@
 using IntimacyAI.Server.Data;
 using IntimacyAI.Server.Models;
 using IntimacyAI.Server.Security;
-using IntimacyAI.Server.Services;
 using IntimacyAI.Server.Hubs;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.AspNetCore.RateLimiting;
@@ -92,7 +91,7 @@ if (!string.IsNullOrWhiteSpace(signingKey))
 builder.Services.AddSingleton<IAnalysisQueue, AnalysisQueue>();
 builder.Services.AddHostedService<AnalysisWorker>();
 builder.Services.AddSingleton<IEncryptionService, EncryptionService>();
-builder.Services.AddSingleton<IntimacyAI.Server.Services.ICoachingService, IntimacyAI.Server.Services.SimpleCoachingService>();
+builder.Services.AddSingleton<ICoachingService, SimpleCoachingService>();
 builder.Services.AddSingleton<IntimacyAI.Server.Security.IKeyDerivationService, IntimacyAI.Server.Security.KeyDerivationService>();
 // Configure inference options and register the inference service implementation
 builder.Services.Configure<OnnxOptions>(builder.Configuration.GetSection("Onnx"));
@@ -492,7 +491,7 @@ app.MapGet("/api/v1/analysis/history", async (string? sessionId, int? skip, int?
 }).RequireRateLimiting("fixed").WithOpenApi();
 
 // Coaching suggestions
-app.MapPost("/api/v1/coaching/suggestions", async (Dictionary<string, object> analysis, Services.ICoachingService coach) =>
+app.MapPost("/api/v1/coaching/suggestions", async (Dictionary<string, object> analysis, ICoachingService coach) =>
 {
     var suggestions = coach.GenerateSuggestions(analysis);
     return Results.Ok(new { suggestions });


### PR DESCRIPTION
Fix C# compile error in `Program.cs` by correcting `ICoachingService` namespace references and removing a duplicate `using` statement.

The previous code had an incorrect fully qualified namespace reference for `ICoachingService` and `SimpleCoachingService`, and a redundant `using` directive, which prevented the server from building.

---
<a href="https://cursor.com/background-agent?bcId=bc-77960949-1847-4a7b-88fb-6b4dbbbcf9df">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-77960949-1847-4a7b-88fb-6b4dbbbcf9df">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

